### PR TITLE
Add support for installing a specific version of librarian-puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RSpec.configure do |c|
 end
 ```
 
-To install a specific version of librarian-puppet, e.g. to support Ruby 1.8.x, replace the ```install_librarian``` line above with ```install_librarian({'librarian_version' => '~>1.5.0'})```.
+To install a specific version of librarian-puppet, e.g. to support Ruby 1.8.x, replace the ```install_librarian``` line above with ```install_librarian(:librarian_version => '~>1.5.0'})```.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ RSpec.configure do |c|
 end
 ```
 
+To install a specific version of librarian-puppet, e.g. to support Ruby 1.8.x, replace the ```install_librarian``` line above with ```install_librarian({'librarian_version' => '~>1.5.0'})```.
+
 ## Contributing
 
 1. Fork it ( http://github.com/afex/beaker-librarian/fork )

--- a/lib/beaker/librarian.rb
+++ b/lib/beaker/librarian.rb
@@ -9,7 +9,7 @@ module Beaker
     # Install rubygems and the librarian-puppet gem onto each host
     def install_librarian(opts = {})
       # Check for 'librarian_version' option
-      librarian_version = opts['librarian_version'] ||= nil
+      librarian_version = opts[:librarian_version] ||= nil
 
       hosts.each do |host|
         install_package host, 'rubygems'

--- a/lib/beaker/librarian.rb
+++ b/lib/beaker/librarian.rb
@@ -8,10 +8,17 @@ module Beaker
 
     # Install rubygems and the librarian-puppet gem onto each host
     def install_librarian(opts = {})
+      # Check for 'librarian_version' option
+      librarian_version = opts['librarian_version'] ||= nil
+
       hosts.each do |host|
         install_package host, 'rubygems'
         install_package host, 'git'
-        on host, 'gem install librarian-puppet'
+        if librarian_version
+          on host, "gem install --no-ri --no-rdoc librarian-puppet -v '#{librarian_version}'" 
+        else
+          on host, 'gem install --no-ri --no-rdoc librarian-puppet' 
+        end
       end
     end
 


### PR DESCRIPTION
Add support for installing a specific version of librarian-puppet, by providing a 'librarian_version' value to `install_librarian`. 

This means that can maintain support for Ruby 1.8.7 on EL6 by install Librarian-Puppet 1.x... 